### PR TITLE
Update interpolation_search.go

### DIFF
--- a/searches/interpolation_search.go
+++ b/searches/interpolation_search.go
@@ -1,4 +1,4 @@
-package main
+package searches
 
 import (
 	"fmt"
@@ -47,9 +47,9 @@ func main() {
 	fmt.Println("Interpolation Search:")
 	var myArr []int
 	for i := 0; i < num; i++ {
-		myArr = append(myArr, i+10000)
+		myArr = append(myArr, i)
 	}
-	x := interpolationSearch(myArr, num, 90000)
+	x := interpolationSearch(myArr, num, 890)
 	if x != -1 {
 		fmt.Println("\tElement found at location: ", x)
 	} else {


### PR DESCRIPTION
Feel free to modify.

On average the interpolation search makes about log(log(n)) comparisons (if the elements are uniformly distributed), where n is the number of elements to be searched. In the worst case (for instance where the numerical values of the keys increase exponentially) it can make up to O(n) comparisons.